### PR TITLE
Upgrade quill, resolves space not working in end of message

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lodash": "4.17.21",
     "nextjs-websocket": "^1.0.7",
     "react-grid-system": "^7.1.1",
-    "react-quill": "^1.3.5",
+    "react-quill": "^2.0.0",
     "react-scroll": "^1.8.1",
     "react-spring": "^9.2.2",
     "styled-jsx": "^4.0.1",


### PR DESCRIPTION
Resolves issue #158 

Problem: 
- Spacebar not working when inserted in end of new message form.

Cause:
- A known issue of react-quill, before `^2.0.0`
- [Reference](https://github.com/zenoamaro/react-quill/issues/795#issuecomment-1131502359)

Solution: 
- Upgrade react-quill to `^2.0.0`